### PR TITLE
support for multiple statements

### DIFF
--- a/lib/tds/connection.ex
+++ b/lib/tds/connection.ex
@@ -60,7 +60,7 @@ defmodule Tds.Connection do
 
   defp call_proc(pid, message, timeout) do
     case GenServer.call(pid, message, timeout) do
-      %Tds.Result{} = res -> {:ok, res}
+      res when is_list(res) -> {:ok, res}
       %Tds.Error{} = err  ->
         {:error, err}
     end

--- a/lib/tds/messages.ex
+++ b/lib/tds/messages.ex
@@ -13,7 +13,7 @@ defmodule Tds.Messages do
   defrecord :msg_ready, [:status]
   defrecord :msg_sql, [:query]
   defrecord :msg_trans, [:trans]
-  defrecord :msg_sql_result, [:columns, :rows, :done]
+  defrecord :msg_sql_resultset, [:results]
   defrecord :msg_sql_empty, []
   defrecord :msg_rpc, [:proc, :query, :params]
   defrecord :msg_error, [:e]
@@ -96,7 +96,7 @@ defmodule Tds.Messages do
       [done: %{}, trans: <<trans::binary>>] ->
         msg_trans(trans: trans)
       tokens ->
-        msg_sql_result(columns: tokens[:columns], rows: tokens[:rows], done: tokens[:done])
+        msg_sql_resultset(results: tokens[:results])
     end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -96,4 +96,25 @@ defmodule QueryTest do
     assert [[nil]] = query("SELECT CAST(NULL as nvarchar(255))",[])
   end
 
+  test "multiple statements", context do
+    assert [[1]] = query("SET NOCOUNT ON; SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT 1;", [])
+  end
+
+  test "multiple datasets", context do
+    assert [[["Hello"]], [["World"]]] = query_multiset("SELECT 'Hello'; SELECT 'World';", [])
+  end
+
+  test "multiple datasets inside stored procedure", context do
+    procname = "multiproc1"
+    create_sp = """
+      CREATE PROCEDURE #{procname} AS
+      BEGIN
+        SELECT 1;
+        SELECT 2;
+      END
+    """
+    query(create_sp, [])
+    assert [[[1]], [[2]]] = query_multiset(procname, [])
+    query("DROP PROCEDURE #{procname}", [])
+  end
 end


### PR DESCRIPTION
Hi Justin, this pull request adds support (& tests) for multiple statements/results in one go, for example `SET NOCOUNT ON; SELECT 1;` and `SELECT 1; SELECT 2;`

Any grievances with the coding style or the code it self please let me know and I'll be happy to change them.

p.s. this is a breaking change for any code depending on the tds library, including tds_ecto. I'd be interested in supporting ecto 2.0 in tds_ecto, but I haven't had the time to do it just yet.

Manos.
