### PR TITLE
Fixed decimal

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -473,14 +473,11 @@ defmodule Tds.Types do
     d_ctx = Decimal.get_context
     d_ctx = %{d_ctx | precision: precision}
     Decimal.set_context d_ctx
-    d = Decimal.new pow10(value,(scale * -1))
-    value = pow10(d.coef, d.exp)
-    value =
+
     case sign do
-      0 -> value * -1
-      _ -> value
+      0 -> Decimal.new(-1, value, (scale * -1))
+      _ -> Decimal.new( 1, value, (scale * -1))
     end
-    Decimal.new value
   end
 
   def decode_char(_collation, <<data::binary>>) do

--- a/lib/tds/utils.ex
+++ b/lib/tds/utils.ex
@@ -67,13 +67,4 @@ defmodule Tds.Utils do
     end
     Connection.next(%{s | statement: "", queue: queue, state: :ready})
   end
-
-  def pow10(num,0), do: num
-  def pow10(num,pow) when pow > 0 do
-    pow10(10*num, pow - 1)
-  end
-
-  def pow10(num,pow) when pow < 0 do
-    pow10(num/10, pow + 1)
-  end
 end


### PR DESCRIPTION
Hi there! I noticed an issue when using this library while working with fixed-precision numeric types in SQL that led to loss of precision.

This patch aims to address that by using arbitrary precision math in the `pow10()` utility function to prevent precision loss when decoding the numeric family of types from SQL Server.

---

Consider for example a `numeric(30,6)` field in SQL server which contains the value `141.710000`

On [line 476](https://github.com/livehelpnow/tds/blob/master/lib/tds/types.ex#L476) of `Tds.Types` this value is first run through `Tds.Utils#pow10(num, -scale)` to scale the value before it is ultimately stored in the arbitrary precision Decimal type.

If we were to invoke `#pow10()` in an IEx session we see that it performs traditional floating point math on the value _before it is boxed in an arbitrary precision context_:

```
iex(8)> Tds.Utils.pow10(141710000, -6)
141.70999999999998
```

Thus this approximate value is what the end-user of the library actually sees. If the user attempts to modify their database based on this value they will accumulate floating point errors in fields they intended to be fixed-point / arbitrary precision!

---

As far as I can tell `Tds.Util#pow10()` is only used in `Tds.Types#decode_decimal()` and thus should only affect the following types: `@tds_data_type_decimal, @tds_data_type_numeric, @tds_data_type_decimaln, @tds_data_type_numericn`
