### PR TITLE
Add test that raises handle exception

### DIFF
--- a/test/handle0_test.exs
+++ b/test/handle0_test.exs
@@ -1,0 +1,43 @@
+defmodule Handle0Test do
+
+  use ExUnit.Case, async: true
+
+  import Tds.TestHelper
+
+  alias Tds
+
+  @tag timeout: 50000
+  @table "foo"
+
+  setup do
+    opts = Application.fetch_env!(:tds, :opts)
+    {:ok, pid} = Tds.start_link(opts)
+
+    {:ok, [pid: pid]}
+  end
+
+  test "Could not find prepared statement with handle 0.", %{pid: pid} = context do
+    query("DROP TABLE #{@table}", [])
+
+    query(
+      """
+      CREATE TABLE #{@table}(
+        [id] int identity(1,1) not null primary key
+      )
+      """,
+      []
+    )
+
+    n = 300
+    for i <- 1..n do
+      result =
+        Tds.query(pid, "SELECT * FROM #{@table} WHERE id = @id", [
+          %Tds.Parameter{name: "@id", value: "7", type: :int}
+        ])
+
+      assert {i, {:ok,_}} = {i, result}
+    end
+
+    query("DROP TABLE #{@table}", [])
+  end
+end


### PR DESCRIPTION
The test raises an exception with the message "Could not find prepared statement with handle 0.".
```
> docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=some!Password' -p 1433:1433 -d microsoft/mssql-server-linux:latest
33aa87dd9ac168c8aaee09e321149d365f43fa3f26c24d8a14598ef4505b9bda
> mix test
Excluding tags: [:manual]

warning: variable "i" is unused
  test/handle0_test.exs:38

................

  1) test Could not find prepared statement with handle 0. (Handle0Test)
     test/handle0_test.exs:19
     match (=) failed
     code:  assert {i, {:ok, _}} = {i, result}
     right: {254,
             {:error,
              %Tds.Error{
                message: nil,
                mssql: %{
                  class: 16,
                  length: 154,
                  line_number: 1,
                  msg_text: "Could not find prepared statement with handle 0.",
                  number: 8179,
                  proc_name: "sp_execute",
                  server_name: "33aa87dd9ac1",
                  state: 4
                }
              }}}
     stacktrace:
       test/handle0_test.exs:38: anonymous fn/3 in Handle0Test."test Could not find prepared statement with handle 0."/1
       (elixir) lib/enum.ex:2932: Enum.reduce_range_inc/4
       test/handle0_test.exs:32: (test)

..............

Finished in 0.8 seconds
32 tests, 1 failure, 1 skipped```