### PR TITLE
fix ex_doc config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Tds.Mixfile do
       name: "Tds",
       source_url: "https://github.com/livehelpnow/tds",
       docs: [
-        main: "Readme",
+        main: "readme",
         extras: ["README.md"]
       ]
     ]


### PR DESCRIPTION
The documentation on Hex broke with the update to 1.0.8. Sorry for that.