### PR TITLE
redirecting to new host after env_change token on login

### DIFF
--- a/lib/tds/messages.ex
+++ b/lib/tds/messages.ex
@@ -163,7 +163,7 @@ defmodule Tds.Messages do
     offset_start = byte_size(login_a) + 4
     username = params[:username]
     password = params[:password]
-    servername = params[:servername] || ""
+    servername = params[:hostname]
 
     username_ucs = to_little_ucs2(username)
     password_ucs = to_little_ucs2(password)

--- a/lib/tds/protocol.ex
+++ b/lib/tds/protocol.ex
@@ -564,18 +564,10 @@ defmodule Tds.Protocol do
     # we got an ENVCHANGE:redirection token, we need to disconnect and start over with new server
     disconnect("redirected", s)
     %{hostname: host, port: port} = tokens[:env_redirect]
-    server = case String.split(host, ".database.windows.net") do
-      [servername, ""] -> 
-        # we are connecting to azure, need to extract servername from host
-        # https://blogs.msdn.microsoft.com/sqlnativeclient/2010/11/30/troubleshooting-sql-azure-applications-with-sql-server-native-client/
-        servername
-      _ -> ""
-    end
     new_opts =
       opts
       |> Keyword.put(:hostname, host)
       |> Keyword.put(:port, port)
-      |> Keyword.put(:servername, server)
     connect(new_opts)
   end
 

--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -17,7 +17,7 @@ defmodule Tds.Tokens do
   # 0xAB
   @tds_token_info 0xAB
   @tds_token_returnvalue 0xAC
-  # @tds_token_loginack       0xAD # 0xAD
+  @tds_token_loginack 0xAD
   # 0xD1 - ROW
   @tds_token_row 0xD1
   # 0xD2 - NBCROW
@@ -39,6 +39,7 @@ defmodule Tds.Tokens do
   @tds_envtype_begintrans 8
   @tds_envtype_committrans 9
   @tds_envtype_rollbacktrans 10
+  @tds_envtype_routing 20
 
   ## Decode Token Stream
   def decode_tokens(tail, tokens) when tail == "" or tail == nil do
@@ -242,20 +243,20 @@ defmodule Tds.Tokens do
       @tds_envtype_packetsize ->
         <<
           new_value_size::unsigned-8,
-          new_value::binary-little-size(new_value_size)-unit(8),
+          new_value::binary(new_value_size, 16),
           old_value_size::unsigned-8,
-          old_value::binary-little-size(old_value_size)-unit(8),
+          old_value::binary(old_value_size, 16),
           rest::binary
         >> = tail
 
         Logger.debug(fn ->
           """
-          Database server configured packetsize to #{new_value} where old value
-          was #{old_value}
+          Database server configured packetsize to #{ucs2_to_utf(new_value)} where old value
+          was #{ucs2_to_utf(old_value)}
           """
         end)
 
-        {tokens |> Keyword.put(:packetsize, new_value), rest}
+        {tokens |> Keyword.put(:packetsize, ucs2_to_utf(new_value)), rest}
 
       @tds_envtype_begintrans ->
         <<
@@ -286,6 +287,23 @@ defmodule Tds.Tokens do
         >> = tail
 
         {tokens |> Keyword.put(:trans, <<0x00>>), rest}
+
+      @tds_envtype_routing ->
+        <<
+          _routing_data_len::little-uint16,
+          0x00, #Protocol MUST be 0, specifying TCP-IP protocol
+          port::little-uint16,
+          alt_host_len::little-uint16,
+          alt_host::binary(alt_host_len, 16),
+          0x00,
+          0x00,
+          rest::binary
+        >> = tail
+        token = %{
+          hostname: ucs2_to_utf(alt_host),
+          port: port
+        }
+        {tokens |> Keyword.put(:env_redirect, token), rest}
     end
   end
 
@@ -411,6 +429,31 @@ defmodule Tds.Tokens do
     #   _ ->  {[done: %{status: status, cmd: cur_cmd, rows: row_count}] ++
     #             tokens, tail}
     # end
+  end
+
+  defp decode_token(
+        <<
+          @tds_token_loginack,
+          _length::little-uint16,
+          interface :: size(8),
+          tds_version::binary(4), 
+          prog_name_len::size(8),
+          prog_name::binary(prog_name_len, 16),
+          major_ver::size(8),
+          minor_ver::size(8),
+          build_hi::size(8),
+          build_low::size(8),
+          tail::binary
+        >>, 
+        tokens
+      ) do
+    token = %{
+      t_sql_only: interface == 1, 
+      tds_version: "0x#{Base.encode16(tds_version)}", 
+      program: "#{ucs2_to_utf(prog_name)}", 
+      version: "#{major_ver}.#{minor_ver}.#{build_hi}.#{build_low}"
+    }
+    {Keyword.put(tokens, :login_ack, token), tail}
   end
 
   defp decode_column_order(<<tail::binary>>, n, columns) when n == 0 do


### PR DESCRIPTION
Hi,
these changes are required to support the `env_change:redirection` token on login. Since the login_ack payload was not parsed, I had to parse the entire login response and make corrections as required.

~The biggest change from a user's perspective is when connecting to an azure database, they now need to specify a new `servername` configuration option~

After the [new commit](https://github.com/livehelpnow/tds/pull/61/commits/e697bdcdb41bdd974554cd3f8edeb6263b2ce5b5) the servername option is no longer needed

The test suite was successfully run on local vm -> local SQL, local vm -> azure sql and azure vm -> azure sql