### PR TITLE
fixing info message token parsing

### DIFF
--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -175,8 +175,9 @@ defmodule Tds.Tokens do
       line_number: line_number
     }
 
-    info_token = Keyword.get(tokens, :info, [])
-    {[[i | info_token] | tokens], tail}
+    tokens =
+      Keyword.update(tokens, :info, [i], fn infos -> [i | infos] end)
+    {tokens, tail}
   end
 
   ## ROW


### PR DESCRIPTION
Hi, during connection initialization (after running the final `ALTER DATABASE [#{database}] SET ALLOW_SNAPSHOT_ISOLATION ON;` statement) I was getting back `%{class: 0, length: 132, line_number: 1, msg_text: "SNAPSHOT ISOLATION is always enabled in this database.", number: 3987, proc_name: "", server_name: "XXXX", state: 1}` but could not read it correctly, the problem was that info tokens were not properly added as `{:info, info_list}` in the tokens keyword_list