### PR TITLE
Support multiple datasets in tds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ iex> {:ok, pid} = Tds.start_link([hostname: "localhost", username: "test_user", 
 {:ok, #PID<0.69.0>}
 
 iex> Tds.query!(pid, "SELECT 'Some Awesome Text' AS MyColumn", [])
-%Tds.Result{columns: ["MyColumn"], rows: [{"Some Awesome Text"}], num_rows: 1}}
+%Tds.Result{columns: ["MyColumn"], rows: [["Some Awesome Text"]], num_rows: 1}
 
 iex> Tds.query!(pid, "INSERT INTO MyTable (MyColumn) VALUES (@my_value)",
 ...> [%Tds.Parameter{name: "@my_value", value: "My Actual Value"}])
 %Tds.Result{columns: nil, rows: nil, num_rows: 1}}
+
+iex> Tds.query!(pid, "SELECT 1; SELECT 2;", [], [multiple_datasets: true])
+[
+  %Tds.Result{columns: [""], num_rows: 1, rows: [[1]]},
+  %Tds.Result{columns: [""], num_rows: 1, rows: [[2]]}
+]
 ```
 
 ## Features

--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -310,125 +310,29 @@ defmodule Tds.Tokens do
   ## DONE
   defp decode_token(
          <<
-           @tds_token_done,
-           status::int16,
+           done_token,
+           status::little-uint16,
            cur_cmd::binary(2),
            row_count::little-size(8)-unit(8),
-           _tail::binary
-         >>,
-         tokens
-       ) do
-    case Keyword.get(tokens, :done) do
-      nil ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          nil
-        }
-
-      %{rows: rows} when row_count > rows ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          nil
-        }
-
-      _ ->
-        {tokens, nil}
-    end
-  end
-
-  ## DONEPROC
-  defp decode_token(
-         <<
-           @tds_token_doneproc,
-           status::int16,
-           cur_cmd::binary(2),
-           row_count::little-size(8)-unit(8),
-           _tail::binary
-         >>,
-         tokens
-       ) do
-    case Keyword.get(tokens, :done) do
-      nil ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          nil
-        }
-
-      %{rows: rows} when row_count > rows ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          nil
-        }
-
-      _ ->
-        {tokens, nil}
-    end
-  end
-
-  ## DONEINPROC
-  defp decode_token(
-         <<
-           @tds_token_doneinproc,
-           status::int16,
-           cur_cmd::little-size(8)-unit(2),
-           row_count::little-size(8)-unit(8),
-          #  _something::binary-size(5),
            tail::binary
          >>,
          tokens
-       ) do
-    case Keyword.get(tokens, :done) do
-      nil ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          tail
-        }
-
-      %{rows: rows} when row_count > rows ->
-        {
-          Keyword.put(tokens, :done, %{
-            status: status,
-            cmd: cur_cmd,
-            rows: row_count
-          }),
-          nil
-        }
-
-      _ ->
-        {tokens, nil}
-    end
-
-    # case tokens do
-    #   [done: done] ->
-    #     cond do
-    #       row_count > done.rows -> {[done: %{status: status, cmd: cur_cmd,
-    #                   rows: row_count}] ++ tokens, nil}
-    #       true -> {tokens, tail}
-    #     end
-    #     {tokens, nil}
-    #   _ ->  {[done: %{status: status, cmd: cur_cmd, rows: row_count}] ++
-    #             tokens, tail}
-    # end
+       )
+       when done_token in [
+         @tds_token_done,
+         @tds_token_doneproc,
+         @tds_token_doneinproc
+       ] do
+    result = %{
+      done: %{status: status, cmd: cur_cmd, rows: row_count},
+      rows: tokens[:rows],
+      columns: tokens[:columns]
+    }
+    updated_tokens =
+      tokens
+      |> Keyword.drop([:rows, :columns])
+      |> Keyword.update(:results, [result], fn results -> [result | results] end)
+    {updated_tokens, tail}
   end
 
   defp decode_token(

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -160,4 +160,26 @@ defmodule QueryTest do
   test "char nulls", context do
     assert [[nil]] = query("SELECT CAST(NULL as nvarchar(255))", [])
   end
+
+  test "multiple statements", context do
+    assert [[1]] = query("SET NOCOUNT ON; SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT 1;", [])
+  end
+
+  test "multiple datasets", context do
+    assert [[["Hello"]], [["World"]]] = query_multiset("SELECT 'Hello'; SELECT 'World';", [])
+  end
+
+  test "multiple datasets inside stored procedure", context do
+    procname = "multiproc1"
+    create_sp = """
+      CREATE PROCEDURE #{procname} AS
+      BEGIN
+        SELECT 1;
+        SELECT 2;
+      END
+    """
+    query(create_sp, [])
+    assert [[[1]], [[2]]] = query_multiset(procname, [])
+    query("DROP PROCEDURE #{procname}", [])
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,6 +19,22 @@ defmodule Tds.TestHelper do
     end
   end
 
+  defmacro query_multiset(statement, params, opts \\ []) do
+    quote do
+      case Tds.query(
+             var!(context)[:pid],
+             unquote(statement),
+             unquote(params),
+             unquote(opts)
+             |> Keyword.put(:multiple_datasets, true)
+           ) do
+        {:ok, results} when is_list(results) ->
+          Enum.map(results, fn %{rows: rows} -> rows end)
+        {:error, %Tds.Error{} = err} -> err
+      end
+    end
+  end
+
   defmacro proc(proc, params, opts \\ []) do
     quote do
       case Connection.proc(


### PR DESCRIPTION
Hi all, I ported this code from the old branch (which was based on the needs of ecto 1.x) to add support for  multiple datasets.

I took extra care to not break anything in tds_ecto, tests in both tds and tds_ecto should all run fine using code from this branch

### Details
* Current tds_behaviour stops parsing at the first `DONEXXX` token. This commit addresses that and gathers all results into a list.
* To ensure tds_ecto/ecto compatibility the first `%Tds.Result{}` is returned in place of a list of results unless the user explicitly asks for multiple results by setting the `multiple_datasets: true` option