### PR TITLE
removed ALTER database statement from session start

### DIFF
--- a/lib/tds/protocol.ex
+++ b/lib/tds/protocol.ex
@@ -638,8 +638,7 @@ defmodule Tds.Protocol do
       "SET ANSI_PADDING ON; ",
       "SET ANSI_WARNINGS ON; ",
       "SET CONCAT_NULL_YIELDS_NULL ON; ",
-      "SET TEXTSIZE 2147483647; ",
-      "ALTER DATABASE [#{database}] SET ALLOW_SNAPSHOT_ISOLATION ON; "
+      "SET TEXTSIZE 2147483647; "
     ]
     |> IO.iodata_to_binary()
     |> send_query(state)


### PR DESCRIPTION
Hi all,
this should fix [#64](https://github.com/livehelpnow/tds/issues/64). I believe this ALTER DATABASE statement is something that should done offline by a DBA since the application user usually does not have the required rights, plus it affects how data is stored on disk and a non-DBA probably has no idea of the implications/trade-offs