### PR TITLE
Fix unnecessary append of possibly large binaries

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -427,8 +427,6 @@ defmodule Tds.Types do
           decode_uuid(data)
 
         data_type_code == @tds_data_type_intn ->
-          data = data <> tail
-
           case length do
             1 ->
               <<val::unsigned-8, _tail::binary>> = data


### PR DESCRIPTION
Hi all, one more pull request trying to fix a performance issue while parsing TDS results. While parsing integers, `Tds.Types.decode_data/2` used to append the whole tail to the currently processed integer, resulting in big performance losses when the whole result is big (e.g. when it also contains lots of `NVARCHAR(MAX)` data).

Unfortunately we're not entirely sure if this change is without side effects because the role of `size` vs. `length` is unclear to us in this context.