### PR TITLE
Allow users to choose between sp_execute and sp_executesql style

### DIFF
--- a/lib/tds.ex
+++ b/lib/tds.ex
@@ -2,6 +2,7 @@ defmodule Tds do
   alias Tds.Query
 
   @timeout 5000
+  @execution_mode :prepare_execute
 
   def start_link(opts \\ []) do
     DBConnection.start_link(Tds.Protocol, default(opts))
@@ -85,6 +86,8 @@ defmodule Tds do
   end
 
   defp default(opts) do
-    Keyword.put_new(opts, :idle_timeout, @timeout)
+    opts
+    |> Keyword.put_new(:idle_timeout, @timeout)
+    |> Keyword.put_new(:execution_mode, @execution_mode)
   end
 end


### PR DESCRIPTION
As discussed in #58, this allows users to choose between the `execution_mode` `prepare_execute` (the default) and `executesql`. `prepare_execute` is implemented via `sp_prepare` + `sp_execute` + `sp_unprepare` while `executesql` uses `sp_executesql` for parametrized queries.

To use it, set `execution_mode` in your Ecto Repo config or pass it to `Tds.start_link/1` with either `prepare_execute` (the default) or `executesql`.

As mentioned in the commit, there are some subtle differences between those two execution modes that can potentially affect your query plans and thus your performance. Brent Ozar has a nice writeup on this topic: https://www.brentozar.com/archive/2018/03/sp_prepare-isnt-good-sp_executesql-performance/.

Tests have been added for the new functionality, but please let me know if there's anything else that should be changed / added. I didn't touch the README or CHANGELOG because I thought you might want to this by yourself :-)