### PR TITLE
Fix MatchError issues in Environment change message

### DIFF
--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -356,9 +356,9 @@ defmodule Tds.Tokens do
       # 0x0D
       @tds_envtype_mirroring_partner ->
         <<
-          0x00,
           new_value_size::unsigned-8,
           _new_value::binary(new_value_size, 16),
+          0x00,
           rest::binary
         >> = tail
 


### PR DESCRIPTION
Old value come after new value

Related: https://github.com/livehelpnow/tds/issues/72