### PR TITLE
account for windows shell newline when running sqlcmd

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -63,35 +63,40 @@ end
 
 opts = Application.get_env(:tds, :opts)
 database = opts[:database]
-{"", 0} = Tds.TestHelper.sqlcmd(opts, """
-IF EXISTS(SELECT * FROM sys.databases where name = '#{database}')
-BEGIN
-  DROP DATABASE [#{database}];
-END;
-CREATE DATABASE [#{database}];
-""")
-{"Changed database context to 'test'.\n", 0} = Tds.TestHelper.sqlcmd(opts, """
-USE [test];
 
-CREATE TABLE altering ([a] int)
+{"", 0} =
+  Tds.TestHelper.sqlcmd(opts, """
+  IF EXISTS(SELECT * FROM sys.databases where name = '#{database}')
+  BEGIN
+    DROP DATABASE [#{database}];
+  END;
+  CREATE DATABASE [#{database}];
+  """)
 
-CREATE TABLE [composite1] ([a] int, [b] text);
-CREATE TABLE [composite2] ([a] int, [b] int, [c] int);
-CREATE TABLE [uniques] ([id] int NOT NULL, CONSTRAINT UIX_uniques_id UNIQUE([id]))
-""")
+{"Changed database context to 'test'." <> _newline, 0} =
+  Tds.TestHelper.sqlcmd(opts, """
+  USE [test];
 
-{"Changed database context to 'test'.\n", 0} = Tds.TestHelper.sqlcmd opts, """
-USE test
-GO
-CREATE SCHEMA test;
-"""
+  CREATE TABLE altering ([a] int)
+
+  CREATE TABLE [composite1] ([a] int, [b] text);
+  CREATE TABLE [composite2] ([a] int, [b] int, [c] int);
+  CREATE TABLE [uniques] ([id] int NOT NULL, CONSTRAINT UIX_uniques_id UNIQUE([id]))
+  """)
+
+{"Changed database context to 'test'." <> _newline, 0} =
+  Tds.TestHelper.sqlcmd(opts, """
+  USE test
+  GO
+  CREATE SCHEMA test;
+  """)
+
 # :dbg.start()
 # :dbg.tracer()
 # :dbg.p(:all, :c)
 # :dbg.tpl(:gen_tcp, :_, [])
 # :dbg.tpl(Tds.Protocol, :_, [])
 # :dbg.tpl(DBConnection, :_, :x)
-
 
 ExUnit.start()
 ExUnit.configure(exclude: [:manual])


### PR DESCRIPTION
Hi @mjaric 

I found some time today to work a bit on this, and started off with something easy :)

When running `mix test` from a windows shell the new line char was different and tried to account for that.
I also ran `mix format` on the `test_helper.exs` file