### PR TITLE
Truncate microseconds to scale of 6

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -801,16 +801,20 @@ defmodule Tds.Types do
   end
 
   def encode_binary_type(%Parameter{value: value}) do
-    length =
-      if value == nil do
-        <<0xFF, 0xFF>>
-      else
-        <<byte_size(value)::little-unsigned-16>>
-      end
-
+    length = length_for_binary(value)
     type = @tds_data_type_bigvarbinary
     data = <<type>> <> length
     {type, data, []}
+  end
+
+  defp length_for_binary(nil), do: <<0xFF, 0xFF>>
+
+  defp length_for_binary(value) do
+    case byte_size(value) do
+      # varbinary(max)
+      value_size when value_size > 8000 -> <<0xFF, 0xFF>>
+      value_size -> <<value_size::little-unsigned-16>>
+    end
   end
 
   def encode_bit_type(%Parameter{}) do
@@ -1327,8 +1331,13 @@ defmodule Tds.Types do
   def encode_data(@tds_data_type_bigvarbinary, nil, _),
     do: <<@tds_plp_null::little-unsigned-64>>
 
-  def encode_data(@tds_data_type_bigvarbinary, value, _),
-    do: <<byte_size(value)::little-unsigned-16>> <> value
+  def encode_data(@tds_data_type_bigvarbinary, value, _) do
+    case byte_size(value) do
+      # varbinary(max) gets encoded in chunks
+      value_size when value_size > 8000 -> encode_plp(value)
+      value_size -> <<value_size::little-unsigned-16>> <> value
+    end
+  end
 
   @doc """
   Data Encoding String Types


### PR DESCRIPTION
Microsoft SQL Server defaults to 7, but Elixir NaiveDateTime supports up to 6

@mjaric I know you have a WIP branch for the encoding/decoding, so not sure if you want to pull this or not.  I added a test with an example datetime2 having a scale of 7, which was giving me NaiveDateTime errors with Elixir 1.8.2.  I have not tested with 1.9+.

Example error:
```
iex(2)> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}}, {123_456, 6}) 
~N[2000-01-01 13:30:15.123456]
iex(3)> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}}, {1_234_567, 7})
** (ArgumentError) cannot convert {{2000, 1, 1}, {13, 30, 15}} to naive datetime, reason: :invalid_time
    (elixir) lib/calendar/naive_datetime.ex:764: NaiveDateTime.from_erl!/3
```