### PR TITLE
Fix compiler warnings

### DIFF
--- a/lib/tds/protocol.ex
+++ b/lib/tds/protocol.ex
@@ -1130,14 +1130,6 @@ defmodule Tds.Protocol do
   end
 
   @impl Access
-  def get(data, key, default) do
-    case fetch(data, key) do
-      {:ok, value} -> value
-      :error       -> default
-    end
-  end
-
-  @impl Access
   def pop(data, key) do
     case fetch(data, key) do
       {:ok, value} -> {value, data}

--- a/lib/tds/protocol.ex
+++ b/lib/tds/protocol.ex
@@ -391,7 +391,7 @@ defmodule Tds.Protocol do
         server =
           str
           |> String.split(";")
-          |> Enum.chunk(2)
+          |> Enum.chunk_every(2)
           |> Enum.reduce([], fn [k, v], acc ->
             k =
               k

--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -1687,6 +1687,7 @@ defmodule Tds.Types do
   # 5 bytes if 5 <= n < = 7.
   def encode_time(nil), do: nil
   def encode_time({h, m, s}), do: encode_time({h, m, s, 0})
+  def encode_time(time), do: encode_time(time, @max_time_scale)
 
   def encode_time({h, m, s}, scale), do: encode_time({h, m, s, 0}, scale)
 
@@ -1708,7 +1709,7 @@ defmodule Tds.Types do
         <<fsec::little-unsigned-40>>
     end
   end
-  def encode_time(time), do: encode_time(time, @max_time_scale)
+
   # DateTime2
   def decode_datetime2(scale, <<data::binary>>) do
     {time, date} =


### PR DESCRIPTION
Hi, @mjaric I'm trying to wrap my head around the code in this library so we can start making some progress on the ecto_sql adapter again. Is this still something you're interested in pursuing? (I'm asking because it's been about 6 months since last commit, maybe you've moved on...)

I see there's a bunch of datetime tests failing here, I figure this would need to be fixed first. It looks like the conversion from datetime tuples to NaiveDateTime was never fully completed, i.e. some tests still expect tuples where the code already returns NaiveDateTime structs. Anything blocking getting this finished (other than your time of course)? Do you have some ideas/pointers for next steps? What can I do to help move this project along?

Thanks!