### PR TITLE
Fix encoding of large binaries over 8000 bytes

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -797,16 +797,20 @@ defmodule Tds.Types do
   end
 
   def encode_binary_type(%Parameter{value: value}) do
-    length =
-      if value == nil do
-        <<0xFF, 0xFF>>
-      else
-        <<byte_size(value)::little-unsigned-16>>
-      end
-
+    length = length_for_binary(value)
     type = @tds_data_type_bigvarbinary
     data = <<type>> <> length
     {type, data, []}
+  end
+
+  defp length_for_binary(nil), do: <<0xFF, 0xFF>>
+
+  defp length_for_binary(value) do
+    case byte_size(value) do
+      # varbinary(max)
+      value_size when value_size > 8000 -> <<0xFF, 0xFF>>
+      value_size -> <<value_size::little-unsigned-16>>
+    end
   end
 
   def encode_bit_type(%Parameter{}) do
@@ -1324,8 +1328,13 @@ defmodule Tds.Types do
   def encode_data(@tds_data_type_bigvarbinary, nil, _),
     do: <<@tds_plp_null::little-unsigned-64>>
 
-  def encode_data(@tds_data_type_bigvarbinary, value, _),
-    do: <<byte_size(value)::little-unsigned-16>> <> value
+  def encode_data(@tds_data_type_bigvarbinary, value, _) do
+    case byte_size(value) do
+      # varbinary(max) gets encoded in chunks
+      value_size when value_size > 8000 -> encode_plp(value)
+      value_size -> <<value_size::little-unsigned-16>> <> value
+    end
+  end
 
   @doc """
   Data Encoding String Types

--- a/test/binary_test.exs
+++ b/test/binary_test.exs
@@ -105,6 +105,24 @@ defmodule BinaryTest do
     # query("DROP TABLE bin_test", [])
   end
 
+  test "Support large binary with length over 8000", _context do
+    value =
+      "W"
+      |> String.repeat(9000)
+      |> :unicode.characters_to_binary(:utf8, {:utf16, :little})
+
+    """
+    DROP TABLE bin_test
+    CREATE TABLE bin_test (varbinary varbinary(max) NULL)
+    INSERT INTO bin_test (varbinary) VALUES (@1)
+    """
+    |> query([
+      %Parameter{name: "@1", value: value, type: :binary}
+    ])
+
+    assert [[^value]] = query("SELECT TOP(1) * FROM bin_test", [])
+  end
+
   test "Binary NULL Types", context do
     query("DROP TABLE bin_test", [])
 


### PR DESCRIPTION
This fixes an issue where inserting a large binary (larger than 8000 bytes) was failing as it was not being specified as `varbinary(max)` (`<<0xFF, 0xFF>>`).