### PR TITLE
Increment name in prepare_params/1

### DIFF
--- a/lib/tds/parameter.ex
+++ b/lib/tds/parameter.ex
@@ -64,7 +64,7 @@ defmodule Tds.Parameter do
         raw_param -> fix_data_type(raw_param, name + 1)
       end
 
-    do_name(tail, name, [param | acc])
+    do_name(tail, name + 1, [param | acc])
   end
 
   def do_name([], _, acc) do


### PR DESCRIPTION
This may be too simple, but it seems to do what I was expecting:
```
iex(1)> Tds.Parameter.prepare_params(["test1", "test2"])
[
  %Tds.Parameter{
    direction: :input,
    length: nil,
    name: "@2",
    type: :string,
    value: "test2"
  },
  %Tds.Parameter{
    direction: :input,
    length: nil,
    name: "@1",
    type: :string,
    value: "test1"
  }
]
```

Plus all the existing tests still pass. :)
Reference to #98  