### PR TITLE
Add missing `:` to atom keys in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Example configuration
 ```elixir
 import Mix.Config
 
-config :your_app, tds_conn,
+config :your_app, :tds_conn,
   hostname: "localhost", 
   username: "test_user", 
   password: "test_password", 
@@ -86,7 +86,7 @@ you can try switching how tds executes queries as below:
 ```elixir
 import Mix.Config
 
-config :your_app, tds_conn,
+config :your_app, :tds_conn,
   hostname: "localhost", 
   username: "test_user", 
   password: "test_password", 


### PR DESCRIPTION
Reading the read me looking for an answer to someone's question about SSL support I noticed that these keys were not atoms, but were suggested to be read as atoms, so I assume its a typo, if its not where does this assignment come from?