### PR TITLE
Correct the database mirroring partner envchange handle code.

### DIFF
--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -355,9 +355,9 @@ defmodule Tds.Tokens do
 
         0x0D ->
           <<
-            0x00,
             new_value_size::unsigned-8,
             _new_value::binary(new_value_size, 16),
+            0x00,
             rest::binary
           >> = tail
 


### PR DESCRIPTION
Got this error when trying to do a query against an MSSQL version 14 instance (or 2017)

```console
** (MatchError) no match of right hand side value: <<15, 69, 0, 67, 0, <redacted> ...>>                                                                                                                                            
    (tds 2.1.1) lib/tds/tokens.ex:362: Tds.Tokens.decode_envchange/2                                                                                                                         
    (tds 2.1.1) lib/tds/tokens.ex:52: Tds.Tokens.decode_tokens/2                                                                                                                             
    (tds 2.1.1) lib/tds/messages.ex:66: Tds.Messages.parse/3                                                                                                                                 
    (tds 2.1.1) lib/tds/protocol.ex:507: Tds.Protocol.decode/2                                                                                                                               
    (tds 2.1.1) lib/tds/protocol.ex:562: Tds.Protocol.login/1                                                                                                                                
    (tds 2.1.1) lib/tds/protocol.ex:408: Tds.Protocol.connect/2                                                                                                                              
    (db_connection 2.2.2) lib/db_connection/connection.ex:69: DBConnection.Connection.connect/2                                                                                              
    (connection 1.0.4) lib/connection.ex:622: Connection.enter_connect/5                                                                                                                     
    (stdlib 3.13) proc_lib.erl:226: :proc_lib.init_p_do_apply/3                                                                                                                              
Last message: nil                                                                                                                                                                            
State: Tds.Protocol
```

This pull request fixes it for me (used the other case clauses and this [TDS doc](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/2b3eb7e5-d43d-4d1b-bf4d-76b9e3afc791) to come up with the fix)

Also, thank you for this lib!