### PR TITLE
Fix double incrementing of the packet number

### DIFF
--- a/lib/tds/messages.ex
+++ b/lib/tds/messages.ex
@@ -601,7 +601,7 @@ defmodule Tds.Messages do
   end
 
   def encode_packets(type, data, id) do
-    header = encode_header(type, data, id: id + 1, status: 1)
+    header = encode_header(type, data, id: id, status: 1)
     [header <> data]
   end
 

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -1,0 +1,113 @@
+defmodule MessagesTest do
+  use ExUnit.Case, async: true
+
+  describe "encode_packets" do
+    test "data length < 4088 is encoded into one packet" do
+      assert [<<
+               # type
+               0x10,
+               # status
+               0x1,
+               # length
+               0x0,
+               0x9,
+               # channel
+               0x0,
+               0x0,
+               # packet number
+               0x1,
+               # window
+               0x0,
+               # data
+               0xFF
+             >>] == Tds.Messages.encode_packets(0x10, <<0xFF>>)
+    end
+
+    test "data length == 4087 is encoded into one packet" do
+      data = :binary.copy(<<0xFF>>, 4087)
+      assert [<<
+               # type
+               0x10,
+               # status
+               0x1,
+               # length
+               0x0F,
+               0xFF,
+               # channel
+               0x0,
+               0x0,
+               # packet number
+               0x1,
+               # window
+               0x0,
+               data::binary
+              >>] == Tds.Messages.encode_packets(0x10, data)
+    end
+
+    test "data length == 4088 is encoded into one packet" do
+      data = :binary.copy(<<0xFF>>, 4088)
+      assert [[<<
+               # type
+               0x10,
+               # status
+               0x1,
+               # length
+               0x10,
+               0x00,
+               # channel
+               0x0,
+               0x0,
+               # packet number
+               0x1,
+               # window
+               0x0
+              >>, <<
+               # data
+               data::binary
+             >>]] == Tds.Messages.encode_packets(0x10, data)
+    end
+
+    test "data length == 4089 is encoded into two packets " do
+      part1 = :binary.copy(<<0xFF>>, 4088)
+      part2 = :binary.copy(<<0xFF>>, 1)
+      data = part1 <> part2
+      assert [[<<
+               # type
+               0x10,
+               # status
+               0x0,
+               # length
+               0x10,
+               0x00,
+               # channel
+               0x0,
+               0x0,
+               # packet number
+               0x1,
+               # window
+               0x0 >>,
+              <<
+               # data
+               part1::binary
+             >>],
+               <<
+               # type
+               0x10,
+               # status
+               0x1,
+               # length
+               0x0,
+               0x9,
+               # channel
+               0x0,
+               0x0,
+               # packet number
+               0x2,
+               # window
+               0x0,
+               # data
+               0xFF
+             >>] == Tds.Messages.encode_packets(0x10, data)
+    end
+  end
+end


### PR DESCRIPTION
This MR fixes an issue where the packet number field of the packet header was incorrectly incremented twice.  This resulted in the packet number fo a single LOGIN7 packet being 2, rather 1.

This violated the TDS protocol definition.  Furthermore, firewall rules that restrict traffic based on the TDS protocol filtered out such violating TDS packets.  Also, it resulted in tools such as Wireshark not being able to properly parse out the TDS header.

### Example 

Here's an example of two LOGIN7 packets.  The packet on the left was generated with SHA 748b2f4f1124a8666b689e86b8f0c64fef11ab2e.  The packet on the right was generated using SHA fe62754a537fedd3f1cb0e308c55cb20f7b31f8c.   As you can see, the packet number is wrong in the left screenshot.

![image](https://user-images.githubusercontent.com/49971671/100177182-32abee80-2e97-11eb-9c69-7966dfb14d40.png)


### Issue Origination

I believe the issue was introduced in SHA 748b2f4f1124a8666b689e86b8f0c64fef11ab2e. 


### Unit Tests

I've added unit test for boundary testing the `encode_packets/3` function.